### PR TITLE
add option sourceMap: true and properly JSON.stringify map file. 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-esnext",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Transform next-generation JavaScript to today's JavaScript",
   "license": "MIT",
   "repository": "sindresorhus/gulp-esnext",

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,8 @@ gulp.task('default', function () {
 
 [Options](https://github.com/square/esnext/blob/b12248e0a0e60df04c5292bf8265b55c42d4b480/lib/index.js#L25) are passed through to esnext.
 
+If `sourceMap: true` is passed in, a SourceMap comment is appended to the bottom of each file.
+
 
 ## License
 


### PR DESCRIPTION
The user cannot realistically define sourceFileName and sourceMapName on their own, as it is on a per-file basis, which doesn't fit cleanly into the gulp way of doing things. This patch solves that issue by providing the capability to use `sourceMap: true` which appends the base64'd source map to the bottom of each output JS file.
