### PR TITLE
Bump esnext / Update URLs of esnext repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "transpiler"
   ],
   "dependencies": {
-    "esnext": "^0.11.1",
+    "esnext": "^0.12.0",
     "gulp-util": "^3.0.0",
     "object-assign": "^1.0.0",
     "through2": "^0.6.1",

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # [gulp](http://gulpjs.com)-esnext [![Build Status](https://travis-ci.org/sindresorhus/gulp-esnext.svg?branch=master)](https://travis-ci.org/sindresorhus/gulp-esnext)
 
-> Transform next-generation JavaScript to today's JavaScript with [esnext](https://github.com/square/esnext)
+> Transform next-generation JavaScript to today's JavaScript with [esnext](https://github.com/esnext/esnext)
 
-*Issues with the output should be reported on the esnext [issue tracker](https://github.com/square/esnext/issues).*
+*Issues with the output should be reported on the esnext [issue tracker](https://github.com/esnext/esnext/issues).*
 
 
 ## Install
@@ -32,7 +32,7 @@ gulp.task('default', function () {
 
 #### options
 
-[Options](https://github.com/square/esnext/blob/b12248e0a0e60df04c5292bf8265b55c42d4b480/lib/index.js#L25) are passed through to esnext.
+[Options](https://github.com/esnext/esnext/blob/fbfba30fb31893bd03cedb73fa97b91fa0b6dd01/lib/index.js#L29) are passed through to esnext.
 
 
 ## Source Maps

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ it('should generate source maps', function (cb) {
 		.pipe(write);
 
 	write.on('data', function (file) {
-		assert.equal(file.sourceMap.mappings, 'AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,UAAC;SAAK,EAAE,EAAE;CAAC');
+		assert.equal(file.sourceMap.mappings, 'AAAA,CAAC,CAAC,IAAI;WAAQ,EAAE;CAAC');
 		var contents = file.contents.toString();
 		assert(/function/.test(contents));
 		assert(/sourceMappingURL=data:application\/json;base64/.test(contents));


### PR DESCRIPTION
- I updated [esnext](https://github.com/esnext/esnext) module to v0.12.0.
- I updated the URLs of esnext repository. `square/esnext` -> `esnext/esnext`
